### PR TITLE
Add diagnostic fields to /api/status and reset endpoint

### DIFF
--- a/.github/workflows/platformio-build.yml
+++ b/.github/workflows/platformio-build.yml
@@ -92,7 +92,7 @@ jobs:
         ls -la deploy/main/
         
     - name: Deploy to GitHub Pages
-      uses: peaceiris/actions-gh-pages@v3
+      uses: peaceiris/actions-gh-pages@v4
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./deploy

--- a/.github/workflows/platformio-build.yml
+++ b/.github/workflows/platformio-build.yml
@@ -83,11 +83,14 @@ jobs:
 
     - name: Prepare Web Flasher Manifest
       run: |
-        # Update the manifest with the actual filenames and version
-        cp flasher/manifest-template.json flasher/manifest.json
-        sed -i "s/FIRMWARE_FILE/..\/alfeedo-v${{ env.VERSION }}-${{ env.BRANCH }}-merged.bin/g" flasher/manifest.json
-        sed -i "s/LATEST/${{ env.VERSION }}/g" flasher/manifest.json
-
+        mkdir -p deploy/main
+        cp flasher/manifest-template.json deploy/main/manifest.json
+        sed -i "s/FIRMWARE_FILE/alfeedo-v${{ env.VERSION }}-${{ env.BRANCH }}-merged.bin/g" deploy/main/manifest.json
+        sed -i "s/LATEST/${{ env.VERSION }}/g" deploy/main/manifest.json
+        cp flasher/index.html deploy/main/index.html
+        cp alfeedo-v${{ env.VERSION }}-${{ env.BRANCH }}-merged.bin deploy/main/
+        ls -la deploy/main/
+        
     - name: Deploy to GitHub Pages
       uses: peaceiris/actions-gh-pages@v3
       with:

--- a/.github/workflows/platformio-build.yml
+++ b/.github/workflows/platformio-build.yml
@@ -92,9 +92,5 @@ jobs:
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: .
-        destination_dir: ${{ env.BRANCH }}
-        publish_files: |
-          flasher/index.html
-          flasher/manifest.json
-          alfeedo-v${{ env.VERSION }}-${{ env.BRANCH }}-merged.bin
+        publish_dir: ./deploy
+        keep_files: true

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,0 +1,101 @@
+# Pull Request: Firmware (mzanetti/alfeedo)
+
+## Title
+Add timer API endpoints, reset endpoint and extended status fields
+
+## Description
+
+This PR adds several new API endpoints and extends the existing `/api/status` 
+response to support richer Home Assistant integration.
+
+### New endpoints
+
+**GET /api/timers**
+Returns the list of scheduled timers stored on the device:
+```json
+{
+  "maxTimers": 10,
+  "timers": [
+    {"id": 0, "time": 420, "mode": "meal"},
+    {"id": 1, "time": 720, "mode": "meal"}
+  ]
+}
+```
+Time is expressed in minutes since midnight (e.g. 420 = 07:00).
+
+**POST /api/timers**
+Adds a new timer:
+```json
+{"time_h_m": "07:00", "mode": "meal"}
+```
+
+**DELETE /api/timers?timer_id=0**
+Deletes a timer by ID.
+
+**POST /api/reset**
+Triggers a remote restart of the ESP32.
+
+### Extended /api/status fields
+The following diagnostic fields were added to the existing `/api/status` response:
+- `wifiRssi` — WiFi signal strength (dBm)
+- `wifiSsid` — connected WiFi network name
+- `ipAddress` — device IP address
+- `uptime` — device uptime in seconds
+- `freeHeap` — free heap memory in bytes
+- `firmwareVersion` — current firmware version string
+
+### Related PR
+These changes are required by the companion HA integration PR:
+https://github.com/mzanetti/ha-alfeedo/pull/[NUMMER]
+
+### Testing
+Tested on physical hardware with the ESP32-based feeder. All endpoints return
+correct responses and timers persist across HA restarts.
+
+---
+
+# Pull Request: HA Integration (mzanetti/ha-alfeedo)
+
+## Title
+Add timer management, diagnostic sensors, motor/fill settings and card UI improvements
+
+## Description
+
+This PR extends the Home Assistant integration with timer management, 
+additional sensors and UI improvements to the custom card.
+
+### New features
+
+**Timer management**
+- New `sensor.alfeedo_timers` entity showing the number of active timers,
+  with the full timer list (id, time, mode) as attributes
+- Timer UI embedded in the custom card: view, add and delete timers directly
+  from the dashboard
+- HA services `alfeedo.add_timer` (time, mode) and `alfeedo.delete_timer` (timer_id)
+  for use in automations
+
+**Diagnostic sensors**
+- WiFi signal strength, SSID, IP address, uptime, free heap memory, firmware version
+- All marked as `EntityCategory.DIAGNOSTIC`
+
+**Motor and fill sensor settings**
+- Number sliders for meal size, snack size and motor speed
+- Number sliders for full/empty fill sensor calibration values
+- Dynamic min/max values read from the ESP32 API
+
+**Reset button**
+- `button.alfeedo_restart_feeder` to remotely reboot the ESP32
+
+### Bug fixes / improvements
+- Lovelace resource URL now includes version number from `manifest.json`
+  to automatically bust the browser cache on updates
+- Old resource entries with a different version are automatically cleaned up on startup
+- `cache_headers` set to `False` to prevent stale JS being served after updates
+
+### Related PR
+Requires firmware changes from:
+https://github.com/mzanetti/alfeedo/pull/[NUMMER]
+
+### Testing
+Tested on physical hardware. All entities, services and card UI functions
+work as expected.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ Follow print and assembly instructions provided with the model files.
 
 Electronics wiring can be simplified by ordering the Alfeedo PCB using the provided Gerber files in [pcb/](https://github.com/mzanetti/alfeedo/tree/main/pcb).
 
-Flash the device using the [web flasher](https://mzanetti.github.io/alfeedo/main/flasher/).
+-Flash the device using the [web flasher](https://mzanetti.github.io/alfeedo/main/flasher/).
+-Connect with the Alfeedo-WIFI-AP
+-Navigate to alfeedo.local and set network credentials.
 
 Note that the provided firmware assumes wiring to look like on the Alfeedo PCB. If instead you prefer using a different setup, you'll have to build the firmware yourself and adjust the pins in hwsettings.h.
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ Follow print and assembly instructions provided with the model files.
 Electronics wiring can be simplified by ordering the Alfeedo PCB using the provided Gerber files in [pcb/](https://github.com/mzanetti/alfeedo/tree/main/pcb).
 
 -Flash the device using the [web flasher](https://mzanetti.github.io/alfeedo/main/flasher/).
+
 -Connect with the Alfeedo-WIFI-AP
+
 -Navigate to alfeedo.local and set network credentials.
 
 Note that the provided firmware assumes wiring to look like on the Alfeedo PCB. If instead you prefer using a different setup, you'll have to build the firmware yourself and adjust the pins in hwsettings.h.

--- a/platformio.ini
+++ b/platformio.ini
@@ -6,7 +6,7 @@ monitor_speed = 115200
 upload_speed = 921600
 build_flags = 
   -std=gnu++17
-  -D CATFEEDER_VERSION=\"1.0.0\" 
+  -D CATFEEDER_VERSION=\"1.0.1-donder24\" 
   -D USE_NTP
 build_unflags = 
   -std=gnu++11

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,101 +1,40 @@
-name: Alfeedo ESP32 
-
-on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
-
-# Geeft de workflow schrijfrechten voor gh-pages
-permissions:
-  contents: write
-
-env:
-  BUILD_TYPE: Release
-
-jobs:
-  build:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v4
-
-    - name: Set up Python 3.13
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.13'
-        update-environment: true
-
-    - name: Install PlatformIO
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install platformio==6.1.19
-
-    - name: Build
-      run: platformio run
-
-    - name: Merge Binaries
-      run: |
-        pip install esptool
-        esptool.py --chip esp32 merge_bin \
-          -o merged-firmware.bin \
-          --flash_mode dio \
-          --flash_size 4MB \
-          0x1000 .pio/build/esp32dev/bootloader.bin \
-          0x8000 .pio/build/esp32dev/partitions.bin \
-          0x10000 .pio/build/esp32dev/firmware.bin
-
-    - name: Extract Version and Rename
-      id: vars
-      run: |
-        VERSION=$(grep "CATFEEDER_VERSION" platformio.ini | sed 's/.*\\\"\\(.*\\)\\\".*/\1/' | tr -d '\\\r\n')
-        echo "VERSION=$VERSION"
-        echo "VERSION=$VERSION" >> $GITHUB_ENV
-        cp .pio/build/esp32dev/firmware.bin alfeedo-v$VERSION-firmware.bin
-        cp merged-firmware.bin alfeedo-v$VERSION-merged.bin
-
-        if [ "${{ github.event_name }}" == "pull_request" ]; then
-          BRANCH="${{ github.head_ref }}"
-        else
-          BRANCH="${{ github.ref_name }}"
-        fi
-        SAFE_BRANCH=$(echo "$BRANCH" | sed 's/\//-/g')
-        echo "BRANCH=$SAFE_BRANCH"
-        echo "BRANCH=$SAFE_BRANCH" >> $GITHUB_ENV
-        cp .pio/build/esp32dev/firmware.bin alfeedo-v$VERSION-$SAFE_BRANCH-firmware.bin
-        cp merged-firmware.bin alfeedo-v$VERSION-$SAFE_BRANCH-merged.bin
-        ls -l
-
-    - name: Archive Artifacts
-      uses: actions/upload-artifact@v4
-      with:
-        name: esp32-binaries
-        path: |
-          alfeedo-v${{ env.VERSION }}-${{ env.BRANCH }}-merged.bin
-          alfeedo-v${{ env.VERSION }}-${{ env.BRANCH }}-firmware.bin
-
-    - name: Create Release
-      uses: softprops/action-gh-release@v1
-      if: startsWith(github.ref, 'refs/tags/')
-      with:
-        files: |
-          alfeedo-v${{ env.VERSION }}-firmware.bin
-          alfeedo-v${{ env.VERSION }}-merged.bin
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Prepare Web Flasher Manifest
-      run: |
-        mkdir -p deploy/${{ env.BRANCH }}
-        cp flasher/manifest-template.json deploy/${{ env.BRANCH }}/manifest.json
-        sed -i "s/FIRMWARE_FILE/..\/alfeedo-v${{ env.VERSION }}-${{ env.BRANCH }}-merged.bin/g" deploy/${{ env.BRANCH }}/manifest.json
-        sed -i "s/LATEST/${{ env.VERSION }}/g" deploy/${{ env.BRANCH }}/manifest.json
-        cp flasher/index.html deploy/${{ env.BRANCH }}/index.html
-        cp alfeedo-v${{ env.VERSION }}-${{ env.BRANCH }}-merged.bin deploy/${{ env.BRANCH }}/
-
-    - name: Deploy to GitHub Pages
-      uses: peaceiris/actions-gh-pages@v3
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./deploy
-        keep_files: true
+[env:esp32dev]
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.34/platform-espressif32.zip
+board = esp32dev
+framework = arduino
+monitor_speed = 115200
+upload_speed = 921600
+build_flags = 
+  -std=gnu++17
+  -D CATFEEDER_VERSION=\"1.0.0\" 
+  -D USE_NTP
+build_unflags = 
+  -std=gnu++11
+monitor_filters = esp32_exception_decoder
+extra_scripts = pre:gzip_embeds.py
+board_build.partitions = min_spiffs.csv
+board_build.embed_txtfiles = 
+  data/style.css.gz
+  data/index.html
+  data/timers.html
+  data/settings.html
+  data/debuglogs.html
+  data/firmware.html
+  data/logs.html
+  data/fillsensorsettings.html
+  data/motorsettings.html
+  data/networksettings.html
+  data/networkchanged.html
+  data/timesettings.html
+  data/reset.html
+  data/favicon.ico.gz
+  data/logo.svg.gz
+lib_ldf_mode=deep
+lib_deps = 
+	esp32async/ESPAsyncWebServer@^3.8.1
+	teemuatlut/TMCStepper@^0.7.3
+	adafruit/Adafruit SSD1306@^2.5.9
+	adafruit/Adafruit_VL53L0X@^1.2.4
+	bblanchon/ArduinoJson@^7.4.2
+	janelia-arduino/TMC2209@^10.1.1
+	gin66/FastAccelStepper@^0.33.9

--- a/platformio.ini
+++ b/platformio.ini
@@ -16,7 +16,7 @@ monitor_speed = 115200
 upload_speed = 921600
 build_flags = 
   -std=gnu++17
-  -D CATFEEDER_VERSION=\"1.0.0\" 
+  -D CATFEEDER_VERSION=\"1.0.1-ddt\" 
   -D USE_NTP
 ;  -D DEBUG_STALLGUARD 
 ;  -D DEBUG_WEBSERVER_API

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,54 +1,101 @@
-; PlatformIO Project Configuration File
-;
-;   Build options: build flags, source filter
-;   Upload options: custom upload port, speed and extra flags
-;   Library options: dependencies, extra library storages
-;   Advanced options: extra scripting
-;
-; Please visit documentation for the other options and examples
-; https://docs.platformio.org/page/projectconf.html
+name: Alfeedo ESP32 
 
-[env:esp32dev]
-platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.34/platform-espressif32.zip
-board = esp32dev
-framework = arduino
-monitor_speed = 115200
-upload_speed = 921600
-build_flags = 
-  -std=gnu++17
-  -D CATFEEDER_VERSION=\"1.0.1-ddt\" 
-  -D USE_NTP
-;  -D DEBUG_STALLGUARD 
-;  -D DEBUG_WEBSERVER_API
-;  -D DEBUG_FILLSENSOR
-;  -D DEBUG_TIMESOURCE
-build_unflags = 
-  -std=gnu++11
-monitor_filters = esp32_exception_decoder
-extra_scripts = pre:gzip_embeds.py
-board_build.partitions = min_spiffs.csv
-board_build.embed_txtfiles = 
-  data/style.css.gz
-  data/index.html
-  data/timers.html
-  data/settings.html
-  data/debuglogs.html
-  data/firmware.html
-  data/logs.html
-  data/fillsensorsettings.html
-  data/motorsettings.html
-  data/networksettings.html
-  data/networkchanged.html
-  data/timesettings.html
-  data/reset.html
-  data/favicon.ico.gz
-  data/logo.svg.gz
-lib_ldf_mode=deep
-lib_deps = 
-	esp32async/ESPAsyncWebServer@^3.8.1
-	teemuatlut/TMCStepper@^0.7.3
-	adafruit/Adafruit SSD1306@^2.5.9
-	adafruit/Adafruit_VL53L0X@^1.2.4
-	bblanchon/ArduinoJson@^7.4.2
-	janelia-arduino/TMC2209@^10.1.1
-	gin66/FastAccelStepper@^0.33.9
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+# Geeft de workflow schrijfrechten voor gh-pages
+permissions:
+  contents: write
+
+env:
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python 3.13
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.13'
+        update-environment: true
+
+    - name: Install PlatformIO
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install platformio==6.1.19
+
+    - name: Build
+      run: platformio run
+
+    - name: Merge Binaries
+      run: |
+        pip install esptool
+        esptool.py --chip esp32 merge_bin \
+          -o merged-firmware.bin \
+          --flash_mode dio \
+          --flash_size 4MB \
+          0x1000 .pio/build/esp32dev/bootloader.bin \
+          0x8000 .pio/build/esp32dev/partitions.bin \
+          0x10000 .pio/build/esp32dev/firmware.bin
+
+    - name: Extract Version and Rename
+      id: vars
+      run: |
+        VERSION=$(grep "CATFEEDER_VERSION" platformio.ini | sed 's/.*\\\"\\(.*\\)\\\".*/\1/' | tr -d '\\\r\n')
+        echo "VERSION=$VERSION"
+        echo "VERSION=$VERSION" >> $GITHUB_ENV
+        cp .pio/build/esp32dev/firmware.bin alfeedo-v$VERSION-firmware.bin
+        cp merged-firmware.bin alfeedo-v$VERSION-merged.bin
+
+        if [ "${{ github.event_name }}" == "pull_request" ]; then
+          BRANCH="${{ github.head_ref }}"
+        else
+          BRANCH="${{ github.ref_name }}"
+        fi
+        SAFE_BRANCH=$(echo "$BRANCH" | sed 's/\//-/g')
+        echo "BRANCH=$SAFE_BRANCH"
+        echo "BRANCH=$SAFE_BRANCH" >> $GITHUB_ENV
+        cp .pio/build/esp32dev/firmware.bin alfeedo-v$VERSION-$SAFE_BRANCH-firmware.bin
+        cp merged-firmware.bin alfeedo-v$VERSION-$SAFE_BRANCH-merged.bin
+        ls -l
+
+    - name: Archive Artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: esp32-binaries
+        path: |
+          alfeedo-v${{ env.VERSION }}-${{ env.BRANCH }}-merged.bin
+          alfeedo-v${{ env.VERSION }}-${{ env.BRANCH }}-firmware.bin
+
+    - name: Create Release
+      uses: softprops/action-gh-release@v1
+      if: startsWith(github.ref, 'refs/tags/')
+      with:
+        files: |
+          alfeedo-v${{ env.VERSION }}-firmware.bin
+          alfeedo-v${{ env.VERSION }}-merged.bin
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Prepare Web Flasher Manifest
+      run: |
+        mkdir -p deploy/${{ env.BRANCH }}
+        cp flasher/manifest-template.json deploy/${{ env.BRANCH }}/manifest.json
+        sed -i "s/FIRMWARE_FILE/..\/alfeedo-v${{ env.VERSION }}-${{ env.BRANCH }}-merged.bin/g" deploy/${{ env.BRANCH }}/manifest.json
+        sed -i "s/LATEST/${{ env.VERSION }}/g" deploy/${{ env.BRANCH }}/manifest.json
+        cp flasher/index.html deploy/${{ env.BRANCH }}/index.html
+        cp alfeedo-v${{ env.VERSION }}-${{ env.BRANCH }}-merged.bin deploy/${{ env.BRANCH }}/
+
+    - name: Deploy to GitHub Pages
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./deploy
+        keep_files: true

--- a/src/webserver/CatServer.h
+++ b/src/webserver/CatServer.h
@@ -1,67 +1,43 @@
 /*
 This file is part of alfeedo.
-
-alfeedo is free software: you can redistribute it and/or modify it under the 
-terms of the GNU General Public License as published by the Free Software 
-Foundation, either version 3 of the License, or (at your option) any later version.
-
-alfeedo is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; 
-without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-See the GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along with alfeedo. 
-If not, see <https://www.gnu.org/licenses/>. 
-
-Copyright (C) 2025-2026 Michael Zanetti <michael_zanetti@gmx.net>
+...
 */
 
-#ifndef CATSERVERAPI_H
-#define CATSERVERAPI_H
+#ifndef CATSERVER_H
+#define CATSERVER_H
 
 #include <Arduino.h>
 #include <ESPAsyncWebServer.h>
 
+#include "webserver/CatServerFrontend.h"
+#include "webserver/CatServerApi.h"
+#include "ResetHandler.h"
+
 class Engine;
 class OTAManager;
 class FillSensor;
+class TimeSource;
 class DisplayController;
 class NetworkConfigManager;
-class TimeSource;
 
-class CatServerApi: public AsyncWebHandler {
+class CatServer {
 public:
-    void begin(Engine* engine, FillSensor* fillSensor, OTAManager* otaManager, DisplayController* displayController, NetworkConfigManager* networkConfigManager, TimeSource* timeSource);
+    CatServer();
+    ~CatServer();
 
-    bool canHandle(AsyncWebServerRequest* request) const override;
-    void handleRequest(AsyncWebServerRequest* request) override;
-    void handleBody(AsyncWebServerRequest *request, uint8_t *data, size_t len, size_t index, size_t total) override;
-    bool isRequestHandlerTrivial() const override {
-        return false;
-    }
+    void begin(Engine* engine, FillSensor* fillSensor, OTAManager* otaManager, TimeSource* timeSource, DisplayController* displayController, NetworkConfigManager* networkConfigManager, ResetFunction resetFunction);
+    void loop();
+
 private:
-    void handleStatus(AsyncWebServerRequest *request);
-    void handleFillSensor(AsyncWebServerRequest *request);
-    void handleTimers(AsyncWebServerRequest *request);
-    void handleLogs(AsyncWebServerRequest *request);
-    void handleFeed(AsyncWebServerRequest *request);
-    void handleDebugLogs(AsyncWebServerRequest *request);
-    void handleReset(AsyncWebServerRequest *request);  // ← nieuw
-    void handleMotorSettings(AsyncWebServerRequest *request);
-    void handleFillSensorSettings(AsyncWebServerRequest *request);
-    void handleTimeSettings(AsyncWebServerRequest *request);
+    AsyncWebServer m_server;
 
-    void handleFeedBody(AsyncWebServerRequest *request, uint8_t *data, size_t len, size_t index, size_t total);
-    void handleTimersBody(AsyncWebServerRequest *request, uint8_t *data, size_t len, size_t index, size_t total);
-    void handleMotorSettingsBody(AsyncWebServerRequest *request, uint8_t *data, size_t len, size_t index, size_t total);
-    void handleFillSensorSettingsBody(AsyncWebServerRequest *request, uint8_t *data, size_t len, size_t index, size_t total);
-    void handleTimeSettingsBody(AsyncWebServerRequest *request, uint8_t *data, size_t len, size_t index, size_t total);
+    CatServerFrontend m_frontend;
+    CatServerApi m_api;
 
-    Engine* m_engine = nullptr;
-    OTAManager* m_otaManager = nullptr;
-    FillSensor* m_fillSensor = nullptr;
-    DisplayController* m_displayController = nullptr;
     NetworkConfigManager* m_networkConfigManager = nullptr;
-    TimeSource* m_timeSource = nullptr;
+
+    void handleNotFound(AsyncWebServerRequest *request);
+
 };
 
-#endif // CATSERVERAPI_H
+#endif // CATSERVER_H

--- a/src/webserver/CatServer.h
+++ b/src/webserver/CatServer.h
@@ -15,41 +15,53 @@ If not, see <https://www.gnu.org/licenses/>.
 Copyright (C) 2025-2026 Michael Zanetti <michael_zanetti@gmx.net>
 */
 
-#ifndef CATSERVER_H
-#define CATSERVER_H
+#ifndef CATSERVERAPI_H
+#define CATSERVERAPI_H
 
 #include <Arduino.h>
 #include <ESPAsyncWebServer.h>
 
-#include "webserver/CatServerFrontend.h"
-#include "webserver/CatServerApi.h"
-#include "ResetHandler.h"
-
 class Engine;
 class OTAManager;
 class FillSensor;
-class TimeSource;
 class DisplayController;
 class NetworkConfigManager;
+class TimeSource;
 
-class CatServer {
+class CatServerApi: public AsyncWebHandler {
 public:
-    CatServer();
-    ~CatServer();
+    void begin(Engine* engine, FillSensor* fillSensor, OTAManager* otaManager, DisplayController* displayController, NetworkConfigManager* networkConfigManager, TimeSource* timeSource);
 
-    void begin(Engine* engine, FillSensor* fillSensor, OTAManager* otaManager, TimeSource* timeSource, DisplayController* displayController, NetworkConfigManager* networkConfigManager, ResetFunction resetFunction);
-    void loop();
-
+    bool canHandle(AsyncWebServerRequest* request) const override;
+    void handleRequest(AsyncWebServerRequest* request) override;
+    void handleBody(AsyncWebServerRequest *request, uint8_t *data, size_t len, size_t index, size_t total) override;
+    bool isRequestHandlerTrivial() const override {
+        return false;
+    }
 private:
-    AsyncWebServer m_server;
+    void handleStatus(AsyncWebServerRequest *request);
+    void handleFillSensor(AsyncWebServerRequest *request);
+    void handleTimers(AsyncWebServerRequest *request);
+    void handleLogs(AsyncWebServerRequest *request);
+    void handleFeed(AsyncWebServerRequest *request);
+    void handleDebugLogs(AsyncWebServerRequest *request);
+    void handleReset(AsyncWebServerRequest *request);  // ← nieuw
+    void handleMotorSettings(AsyncWebServerRequest *request);
+    void handleFillSensorSettings(AsyncWebServerRequest *request);
+    void handleTimeSettings(AsyncWebServerRequest *request);
 
-    CatServerFrontend m_frontend;
-    CatServerApi m_api;
+    void handleFeedBody(AsyncWebServerRequest *request, uint8_t *data, size_t len, size_t index, size_t total);
+    void handleTimersBody(AsyncWebServerRequest *request, uint8_t *data, size_t len, size_t index, size_t total);
+    void handleMotorSettingsBody(AsyncWebServerRequest *request, uint8_t *data, size_t len, size_t index, size_t total);
+    void handleFillSensorSettingsBody(AsyncWebServerRequest *request, uint8_t *data, size_t len, size_t index, size_t total);
+    void handleTimeSettingsBody(AsyncWebServerRequest *request, uint8_t *data, size_t len, size_t index, size_t total);
 
+    Engine* m_engine = nullptr;
+    OTAManager* m_otaManager = nullptr;
+    FillSensor* m_fillSensor = nullptr;
+    DisplayController* m_displayController = nullptr;
     NetworkConfigManager* m_networkConfigManager = nullptr;
-
-    void handleNotFound(AsyncWebServerRequest *request);
-
+    TimeSource* m_timeSource = nullptr;
 };
 
-#endif // CATSERVER_H
+#endif // CATSERVERAPI_H

--- a/src/webserver/CatServerApi.cpp
+++ b/src/webserver/CatServerApi.cpp
@@ -144,6 +144,7 @@ void CatServerApi::handleStatus(AsyncWebServerRequest *request) {
     doc["ipAddress"] = WiFi.localIP().toString();
     doc["uptime"]    = millis() / 1000;
     doc["freeHeap"]  = ESP.getFreeHeap();
+    doc["firmwareVersion"]  = CATFEEDER_VERSION;
  
     String response;
     serializeJson(doc, response);

--- a/src/webserver/CatServerApi.cpp
+++ b/src/webserver/CatServerApi.cpp
@@ -25,6 +25,7 @@ Copyright (C) 2025-2026 Michael Zanetti <michael_zanetti@gmx.net>
 #include "NetworkConfigManager.h"
 #include "Logging.h"
 #include "TimeSource.h"
+#include <WiFi.h>
 
 #include <map>
 #include <time.h>
@@ -134,6 +135,13 @@ void CatServerApi::handleStatus(AsyncWebServerRequest *request) {
     JsonObject nextTimerJson = doc["nextTimer"].to<JsonObject>();    
     nextTimerJson["time"] = m_engine->nextTimer().time();
     nextTimerJson["mode"] = TimerEntry::timerModeToString(m_engine->nextTimer().mode());
+
+    // --- WiFi & system diagnostics ---
+    doc["wifiRssi"]  = WiFi.RSSI();                  // signaalsterkte in dBm (bv. -65)
+    doc["wifiSsid"]  = WiFi.SSID();                  // naam van het netwerk
+    doc["ipAddress"] = WiFi.localIP().toString();    // IP-adres van de ESP32
+    doc["uptime"]    = millis() / 1000;              // uptime in seconden
+    doc["freeHeap"]  = ESP.getFreeHeap();            // vrij RAM in bytes
 
     String response;
     serializeJson(doc, response);

--- a/src/webserver/CatServerApi.cpp
+++ b/src/webserver/CatServerApi.cpp
@@ -1,23 +1,23 @@
 /*
 This file is part of alfeedo.
-
+ 
 alfeedo is free software: you can redistribute it and/or modify it under the 
 terms of the GNU General Public License as published by the Free Software 
 Foundation, either version 3 of the License, or (at your option) any later version.
-
+ 
 alfeedo is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; 
 without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 See the GNU General Public License for more details.
-
+ 
 You should have received a copy of the GNU General Public License along with alfeedo. 
 If not, see <https://www.gnu.org/licenses/>. 
-
+ 
 Copyright (C) 2025-2026 Michael Zanetti <michael_zanetti@gmx.net>
 */
-
+ 
 #include <ArduinoJson.h>
 #include "CatServerApi.h"
-
+ 
 #include "Engine.h"
 #include "OTAManager.h"
 #include "FillSensor.h"
@@ -26,12 +26,13 @@ Copyright (C) 2025-2026 Michael Zanetti <michael_zanetti@gmx.net>
 #include "Logging.h"
 #include "TimeSource.h"
 #include <WiFi.h>
-
+#include <esp_system.h>
+ 
 #include <map>
 #include <time.h>
-
+ 
 LoggingCategory lcApi("Api");
-
+ 
 void CatServerApi::begin(Engine *engine, FillSensor *fillSensor, OTAManager *otaManager, DisplayController *displayController, NetworkConfigManager *networkConfigManager, TimeSource *timeSource) {
     m_engine = engine;
     m_otaManager = otaManager;
@@ -40,17 +41,17 @@ void CatServerApi::begin(Engine *engine, FillSensor *fillSensor, OTAManager *ota
     m_networkConfigManager = networkConfigManager;
     m_timeSource = timeSource;
 }
-
+ 
 bool CatServerApi::canHandle(AsyncWebServerRequest *request) const {
         return request->url().startsWith("/api/");
 }
-
+ 
 void CatServerApi::handleRequest(AsyncWebServerRequest *request) {
     String fullPath = request->url();
-
+ 
     int apiIndex = fullPath.indexOf("/api/");
     String endpoint = fullPath.substring(apiIndex + 4);
-
+ 
 #if DEBUG_WEBSERVER_API
     String argList = "";
     for (uint8_t i = 0; i < request->args(); i++) {
@@ -58,7 +59,7 @@ void CatServerApi::handleRequest(AsyncWebServerRequest *request) {
     }
     logDebug(lcApi, "Handling request for path: " + fullPath + " Method: " + String((int)request->method()) + " Args: " + String(request->args()) + " [" + argList + "]");
 #endif
-
+ 
     std::map<String, void (CatServerApi::*)(AsyncWebServerRequest *)> routeHandlers = {
         {"/status", &CatServerApi::handleStatus},
         {"/fillsensor", &CatServerApi::handleFillSensor},
@@ -66,11 +67,12 @@ void CatServerApi::handleRequest(AsyncWebServerRequest *request) {
         {"/logs", &CatServerApi::handleLogs},
         {"/feed", &CatServerApi::handleFeed},
         {"/debuglogs", &CatServerApi::handleDebugLogs},
+        {"/reset", &CatServerApi::handleReset},
         {"/settings/motor", &CatServerApi::handleMotorSettings},
         {"/settings/fillsensor", &CatServerApi::handleFillSensorSettings},
         {"/settings/time", &CatServerApi::handleTimeSettings}
     };
-
+ 
     auto it = routeHandlers.find(endpoint);;
     if (it != routeHandlers.end()) {
         (this->*(it->second))(request);
@@ -80,13 +82,13 @@ void CatServerApi::handleRequest(AsyncWebServerRequest *request) {
     logWarning(lcApi, "No handler found for path: " + fullPath);
     request->send(404, "application/json", "{\"status\":\"error\",\"error\":\"API Endpoint Not Found\"}");
 }
-
+ 
 void CatServerApi::handleBody(AsyncWebServerRequest *request, uint8_t *data, size_t len, size_t index, size_t total) {
     String fullPath = request->url();
-
+ 
     int apiIndex = fullPath.indexOf("/api/");
     String endpoint = fullPath.substring(apiIndex + 4);
-
+ 
 #if DEBUG_WEBSERVER_API
     String argList = "";
     for (uint8_t i = 0; i < request->args(); i++) {
@@ -94,7 +96,7 @@ void CatServerApi::handleBody(AsyncWebServerRequest *request, uint8_t *data, siz
     }
     logInfo(lcApi, "Handling body request for path: " + fullPath + " Method: " + String((int)request->method()) + " Args: " + String(request->args()) + " [" + argList + "]");
 #endif
-
+ 
     std::map<String, void (CatServerApi::*)(AsyncWebServerRequest *, uint8_t *, size_t, size_t, size_t)> routeHandlers = {
         {"/feed", &CatServerApi::handleFeedBody},
         {"/timers", &CatServerApi::handleTimersBody},
@@ -102,18 +104,18 @@ void CatServerApi::handleBody(AsyncWebServerRequest *request, uint8_t *data, siz
         {"/settings/fillsensor", &CatServerApi::handleFillSensorSettingsBody},
         {"/settings/time", &CatServerApi::handleTimeSettingsBody}
     };
-
+ 
     auto it = routeHandlers.find(endpoint);;
     if (it != routeHandlers.end()) {
         (this->*(it->second))(request, data, len, index, total);
         return;
     }
-
+ 
     logWarning(lcApi, "No body handler found for path: " + fullPath);
-
+ 
     request->send(404, "application/json", "{\"status\":\"error\",\"error\":\"API Endpoint Not Found\"}");
 }
-
+ 
 void CatServerApi::handleStatus(AsyncWebServerRequest *request) {
     std::map<Engine::State, String> stateMap = {
         {Engine::State::Idle, "idle"},
@@ -135,19 +137,31 @@ void CatServerApi::handleStatus(AsyncWebServerRequest *request) {
     JsonObject nextTimerJson = doc["nextTimer"].to<JsonObject>();    
     nextTimerJson["time"] = m_engine->nextTimer().time();
     nextTimerJson["mode"] = TimerEntry::timerModeToString(m_engine->nextTimer().mode());
-
+ 
     // --- WiFi & system diagnostics ---
-    doc["wifiRssi"]  = WiFi.RSSI();                  // signaalsterkte in dBm (bv. -65)
-    doc["wifiSsid"]  = WiFi.SSID();                  // naam van het netwerk
-    doc["ipAddress"] = WiFi.localIP().toString();    // IP-adres van de ESP32
-    doc["uptime"]    = millis() / 1000;              // uptime in seconden
-    doc["freeHeap"]  = ESP.getFreeHeap();            // vrij RAM in bytes
-
+    doc["wifiRssi"]  = WiFi.RSSI();
+    doc["wifiSsid"]  = WiFi.SSID();
+    doc["ipAddress"] = WiFi.localIP().toString();
+    doc["uptime"]    = millis() / 1000;
+    doc["freeHeap"]  = ESP.getFreeHeap();
+ 
     String response;
     serializeJson(doc, response);
     request->send(200, "application/json", response);
 }
-
+ 
+void CatServerApi::handleReset(AsyncWebServerRequest *request) {
+    if (request->method() != HTTP_POST) {
+        request->send(405, "application/json", "{\"status\":\"error\",\"error\":\"Method Not Allowed\"}");
+        return;
+    }
+    logInfo(lcApi, "Reset requested via API — restarting ESP32");
+    request->send(200, "application/json", "{\"status\":\"ok\",\"message\":\"Restarting...\"}");
+    // Kleine vertraging zodat het antwoord nog verstuurd wordt voor de reset
+    delay(200);
+    esp_restart();
+}
+ 
 void CatServerApi::handleFillSensor(AsyncWebServerRequest *request) {
     JsonDocument doc;
     doc["measurement"] = m_fillSensor->measurement();
@@ -156,14 +170,14 @@ void CatServerApi::handleFillSensor(AsyncWebServerRequest *request) {
     serializeJson(doc, output);
     request->send(200, "application/json", output);
 }
-
+ 
 void CatServerApi::handleTimers(AsyncWebServerRequest *request) {
     if (request->method() == HTTP_POST || request->method() == HTTP_PUT) {
         logDebug(lcApi, "handleTimer API POST/PUT request received");
         // processed in handleTimersBody, just return here
         return; 
     }
-
+ 
     if (request->method() == HTTP_DELETE) {
         logDebug(lcApi, "handleTimer API DELETE request received");
         if (!request->hasArg("timer_id")) {
@@ -179,7 +193,7 @@ void CatServerApi::handleTimers(AsyncWebServerRequest *request) {
         request->send(200, "application/json", "{\"status\":\"success\"}");
         return;
     }
-
+ 
     JsonDocument doc;
     doc["maxTimers"] = Engine::MaxTimers;
     JsonArray timers = doc["timers"].to<JsonArray>();
@@ -194,35 +208,35 @@ void CatServerApi::handleTimers(AsyncWebServerRequest *request) {
     serializeJson(doc, output);
     request->send(200, "application/json", output);
 }
-
+ 
 void CatServerApi::handleTimersBody(AsyncWebServerRequest *request, uint8_t *data, size_t len, size_t index, size_t total) {
     logDebug(lcApi, "Handling timer body data: " + String(len) + " bytes, index: " + String(index) + ", total: " + String(total));
-
+ 
     if (index + len < total) {
         logError(lcApi, "Received incomplete timer data: " + String(index + len) + " bytes received, expected total: " + String(total));
         request->send(400, "application/json", "{\"status\":\"error\",\"error\":\"Incomplete data received\"}");
         return; 
     }
-
+ 
     if (request->method() == HTTP_POST) {
         logInfo(lcApi, "handleTimersBody POST body received. Adding new timer.");
         JsonDocument doc; 
         DeserializationError error = deserializeJson(doc, data, len);
-
+ 
         if (error) {
             logWarning(lcApi, "JSON Deserialization failed");
             request->send(400, "application/json", "{\"status\":\"error\",\"error\":\"Invalid JSON\"}");
             return;
         }
-
+ 
         const char* timeString = doc["time_h_m"];
         const char* mode = doc["mode"];
-
+ 
         if (!timeString || !mode) {
             request->send(400, "application/json", "{\"status\":\"error\",\"error\":\"Missing fields\"}");
             return;
         }
-
+ 
         String ts(timeString);
         int hours = ts.substring(0, 2).toInt();
         int minutes = ts.substring(3, 5).toInt();
@@ -232,30 +246,30 @@ void CatServerApi::handleTimersBody(AsyncWebServerRequest *request, uint8_t *dat
             request->send(400, "application/json", "{\"status\":\"error\",\"error\":\"Failed to add timer. Maximum number of timers reached.\"}");
             return;
         }
-
+ 
         request->send(200, "application/json", "{\"status\":\"success\"}");
     }
-
+ 
     if (request->method() == HTTP_PUT) {
         logInfo(lcApi, "handleTimersBody PUT body received. Updating timer.");
         JsonDocument doc; 
         DeserializationError error = deserializeJson(doc, data, len);
-
+ 
         if (error) {
             logWarning(lcApi, "JSON Deserialization failed");
             request->send(400, "application/json", "{\"status\":\"error\",\"error\":\"Invalid JSON\"}");
             return;
         }
-
+ 
         const char* timerIdStr = doc["timer_id"];
         const char* timeString = doc["time_h_m"];
         const char* mode = doc["mode"];
-
+ 
         if (!timerIdStr || !timeString || !mode) {
             request->send(400, "application/json", "{\"status\":\"error\",\"error\":\"Missing fields\"}");
             return;
         }
-
+ 
         int id = atoi(timerIdStr);
         String ts(timeString);
         int hours = ts.substring(0, 2).toInt();
@@ -266,34 +280,33 @@ void CatServerApi::handleTimersBody(AsyncWebServerRequest *request, uint8_t *dat
             request->send(400, "application/json", "{\"status\":\"error\",\"error\":\"Failed to update timer.\"}");
             return;
         }
-
+ 
         logInfo(lcApi, "Timer updated");
         request->send(200, "application/json", "{\"status\":\"success\"}");
     }
-
+ 
 }
-
+ 
 void CatServerApi::handleLogs(AsyncWebServerRequest *request) {
     logDebug(lcApi, "Handling /logs request");
-
+ 
     std::vector<Engine::LogEntry> logs = m_engine->logEntries();
     
     JsonDocument doc;
     JsonArray logArray = doc["logs"].to<JsonArray>();
-
+ 
     for (const auto& logEntry : logs) {
         JsonObject logObject = logArray.add<JsonObject>();
         logObject["timestamp"] = logEntry.timestamp;
         
-        // Use safer mapping to prevent crashes on unknown types
         if (logEntry.type == Engine::LogEntry::TypeManualFeed) logObject["type"] = "manual";
         else if (logEntry.type == Engine::LogEntry::TypeTimerFeed) logObject["type"] = "timer";
         else logObject["type"] = "unknown";
-
+ 
         if (logEntry.mode == Engine::FeedingMode::Meal) logObject["mode"] = "meal";
         else if (logEntry.mode == Engine::FeedingMode::Snack) logObject["mode"] = "snack";
         else logObject["mode"] = "unknown";
-
+ 
         logObject["stallCount"] = logEntry.stallCount;
         logObject["aborted"] = logEntry.aborted;
         logObject["fillLevel"] = logEntry.fillLevel;
@@ -302,7 +315,7 @@ void CatServerApi::handleLogs(AsyncWebServerRequest *request) {
     serializeJson(doc, output);
     request->send(200, "application/json", output);
 }
-
+ 
 void CatServerApi::handleDebugLogs(AsyncWebServerRequest *request) {
     JsonDocument doc;
     JsonArray logs = doc["logs"].to<JsonArray>();
@@ -317,7 +330,7 @@ void CatServerApi::handleDebugLogs(AsyncWebServerRequest *request) {
     serializeJson(doc, output);
     request->send(200, "application/json", output);
 }
-
+ 
 void CatServerApi::handleFeedBody(AsyncWebServerRequest *request, uint8_t *data, size_t len, size_t index, size_t total) {
     
     JsonDocument input;
@@ -327,20 +340,20 @@ void CatServerApi::handleFeedBody(AsyncWebServerRequest *request, uint8_t *data,
         logWarning(lcApi, "deserializeJson() failed: " + String(error.c_str()));
         return;
     }
-
+ 
     request->_tempObject = new String(input["mode"].as<String>());
 }
-
+ 
 void CatServerApi::handleFeed(AsyncWebServerRequest *request) {
-
+ 
     if (request->method() != HTTP_POST) {
         request->send(404, "application/json", "{\"status\":\"error\",\"error\":\"API Endpoint Not Found\"}");
         return;
     }
-
+ 
     int status = 200;
     String errorMessage;
-
+ 
     if (request->_tempObject == nullptr) {
         logWarning(lcApi, "Feed mode not found in request");
         request->send(400, "application/json", "{\"status\":\"error\",\"error\":\"missing feed mode\"}");
@@ -348,7 +361,7 @@ void CatServerApi::handleFeed(AsyncWebServerRequest *request) {
     }
     String *mode = static_cast<String*>(request->_tempObject);
     request->_tempObject = nullptr;
-
+ 
     if (*mode == "meal") {
         m_engine->feed();
     } else if (*mode == "snack") {
@@ -359,7 +372,7 @@ void CatServerApi::handleFeed(AsyncWebServerRequest *request) {
     }
      
     delete mode;
-
+ 
     JsonDocument doc;
     doc["status"] = status;
     doc["errorMessage"] = errorMessage;
@@ -367,14 +380,14 @@ void CatServerApi::handleFeed(AsyncWebServerRequest *request) {
     serializeJson(doc, output);
     logDebug(lcApi, "API POST response: " + String(status) + ": " + output);
     request->send(status, "application/json", output);
-
+ 
 }
-
+ 
 void CatServerApi::handleMotorSettings(AsyncWebServerRequest *request) {
     if (request->method() == HTTP_POST) {
         return;
     }
-
+ 
     if (request->method() == HTTP_GET) {
         JsonDocument doc;
         doc["minSpeed"] = m_engine->minSpeed();
@@ -389,10 +402,10 @@ void CatServerApi::handleMotorSettings(AsyncWebServerRequest *request) {
         request->send(200, "application/json", output);
         return;
     }
-
+ 
     request->send(404, "application/json", "{\"status\":\"error\",\"error\":\"API Endpoint Not Found\"}");
 }
-
+ 
 void CatServerApi::handleMotorSettingsBody(AsyncWebServerRequest *request, uint8_t *data, size_t len, size_t index, size_t total) {
     JsonDocument input;
     DeserializationError error = deserializeJson(input, data, len);
@@ -402,29 +415,29 @@ void CatServerApi::handleMotorSettingsBody(AsyncWebServerRequest *request, uint8
         request->send(400, "application/json", "{\"status\":\"error\",\"error\":\"Invalid JSON\"}");
         return;
     }
-
+ 
     JsonVariant speedVariant = input["speed"];
     JsonVariant revolutionsPerPortionVariant = input["revolutionsPerPortion"];
     JsonVariant revolutionsPerSnackVariant = input["revolutionsPerSnack"];
     float speed = speedVariant.as<float>();
     float revolutionsPerPortion = revolutionsPerPortionVariant.as<float>();
     float revolutionsPerSnack = revolutionsPerSnackVariant.as<float>();
-
+ 
     if (!speedVariant.isNull() && (speed < m_engine->minSpeed() || speed > m_engine->maxSpeed())) {
         request->send(400, "application/json", "{\"status\":\"error\",\"error\":\"Speed value out of range\"}");
         return;
     }
-
+ 
     if (!revolutionsPerPortionVariant.isNull() && (revolutionsPerPortion < m_engine->minRevolutionsPerPortion() || revolutionsPerPortion > m_engine->maxRevolutionsPerPortion())) {
         request->send(400, "application/json", "{\"status\":\"error\",\"error\":\"Revolutions per portion value out of range\"}");
         return;
     }
-
+ 
     if (!revolutionsPerSnackVariant.isNull() && (revolutionsPerSnack < m_engine->minRevolutionsPerPortion() || revolutionsPerSnack > m_engine->maxRevolutionsPerPortion())) {
         request->send(400, "application/json", "{\"status\":\"error\",\"error\":\"Revolutions per snack value out of range\"}");
         return;
     }
-
+ 
     if (!speedVariant.isNull()) {
         m_engine->setSpeed(speed);
     }
@@ -434,15 +447,15 @@ void CatServerApi::handleMotorSettingsBody(AsyncWebServerRequest *request, uint8
     if (!revolutionsPerSnackVariant.isNull()) {
         m_engine->setRevolutionsPerSnack(revolutionsPerSnack);
     }
-
+ 
     request->send(200, "application/json", "{\"status\":\"success\"}");
 }   
-
+ 
 void CatServerApi::handleFillSensorSettings(AsyncWebServerRequest *request) {
     if (request->method() == HTTP_POST) {
         return;
     }
-
+ 
     if (request->method() == HTTP_GET) {
         JsonDocument doc;
         doc["emptyMeasurement"] = m_fillSensor->emptyMeasurement();
@@ -452,10 +465,10 @@ void CatServerApi::handleFillSensorSettings(AsyncWebServerRequest *request) {
         request->send(200, "application/json", output);
         return;
     }
-
+ 
     request->send(404, "application/json", "{\"status\":\"error\",\"error\":\"API Endpoint Not Found\"}");
 }
-
+ 
 void CatServerApi::handleFillSensorSettingsBody(AsyncWebServerRequest *request, uint8_t *data, size_t len, size_t index, size_t total) {
     JsonDocument input;
     DeserializationError error = deserializeJson(input, data, len);
@@ -465,33 +478,33 @@ void CatServerApi::handleFillSensorSettingsBody(AsyncWebServerRequest *request, 
         request->send(400, "application/json", "{\"status\":\"error\",\"error\":\"Invalid JSON\"}");
         return;
     }
-
+ 
     JsonVariant emptyMeasurementVariant = input["emptyMeasurement"];
     JsonVariant fullMeasurementVariant = input["fullMeasurement"];
     int emptyMeasurement = emptyMeasurementVariant.as<int>();
     int fullMeasurement = fullMeasurementVariant.as<int>();
-
+ 
     if (emptyMeasurementVariant.isNull() || fullMeasurementVariant.isNull()) {
         request->send(400, "application/json", "{\"status\":\"error\",\"error\":\"Missing parameters\"}");
         return;
     }
-
+ 
     if ((fullMeasurement >= emptyMeasurement)) {
         request->send(400, "application/json", "{\"status\":\"error\",\"error\":\"Full measurement value must be smaller than empty measurement value\"}");
         return;
     }
-
+ 
     m_fillSensor->setEmptyMeasurement(emptyMeasurement);
     m_fillSensor->setFullMeasurement(fullMeasurement);
-
+ 
     request->send(200, "application/json", "{\"status\":\"success\"}");
 }   
-
+ 
 void CatServerApi::handleTimeSettings(AsyncWebServerRequest *request) {
     if (request->method() == HTTP_POST) {
         return;
     }
-
+ 
     if (request->method() == HTTP_GET) {
         JsonDocument doc;
         doc["currentDateTime"] = m_timeSource->currentDateTimeString();
@@ -503,10 +516,10 @@ void CatServerApi::handleTimeSettings(AsyncWebServerRequest *request) {
         request->send(200, "application/json", output);
         return;
     }
-
+ 
     request->send(404, "application/json", "{\"status\":\"error\",\"error\":\"API Endpoint Not Found\"}");
 }
-
+ 
 void CatServerApi::handleTimeSettingsBody(AsyncWebServerRequest *request, uint8_t *data, size_t len, size_t index, size_t total) {
     JsonDocument input;
     DeserializationError error = deserializeJson(input, data, len);
@@ -516,7 +529,7 @@ void CatServerApi::handleTimeSettingsBody(AsyncWebServerRequest *request, uint8_
         request->send(400, "application/json", "{\"status\":\"error\",\"error\":\"Invalid JSON\"}");
         return;
     }
-
+ 
     JsonVariant timezone = input["timezone"];
     if (!timezone.isNull()) {
         if (!m_timeSource->setTimeZone(timezone.as<String>())) {
@@ -524,7 +537,7 @@ void CatServerApi::handleTimeSettingsBody(AsyncWebServerRequest *request, uint8_
             return;
         }   
     }
-
+ 
     JsonVariant datetime = input["datetime"];
     if (!datetime.isNull()) {
         String datetimeString = datetime.as<String>();
@@ -536,6 +549,6 @@ void CatServerApi::handleTimeSettingsBody(AsyncWebServerRequest *request, uint8_
         tm.tm_isdst = -1;
         m_timeSource->setCurrentDateTime(tm);
     }
-
+ 
     request->send(200, "application/json", "{\"status\":\"success\"}");
 }

--- a/src/webserver/CatServerApi.h
+++ b/src/webserver/CatServerApi.h
@@ -45,6 +45,7 @@ private:
     void handleLogs(AsyncWebServerRequest *request);
     void handleFeed(AsyncWebServerRequest *request);
     void handleDebugLogs(AsyncWebServerRequest *request);
+    void handleReset(AsyncWebServerRequest *request);
     void handleMotorSettings(AsyncWebServerRequest *request);
     void handleFillSensorSettings(AsyncWebServerRequest *request);
     void handleTimeSettings(AsyncWebServerRequest *request);


### PR DESCRIPTION
## Summary

This PR extends the REST API with additional diagnostic information and a remote reset capability.

### Changes to /api/status (GET)
The following diagnostic fields were added to the existing response:
- `wifiRssi` — WiFi signal strength (dBm)
- `wifiSsid` — connected WiFi network name
- `ipAddress` — device IP address
- `uptime` — device uptime in seconds
- `freeHeap` — free heap memory in bytes
- `firmwareVersion` — current firmware version string

### New endpoint: POST /api/reset
Triggers a remote restart of the ESP32.
Returns `{"status":"ok","message":"Restarting..."}` before restarting.

### Motivation
These changes enable richer Home Assistant integration — diagnostic sensors 
and a restart button can now be exposed as HA entities.

Related HA integration PR: https://github.com/mzanetti/ha-alfeedo/pull/[NUMMER]

### Testing
Tested on physical hardware. All endpoints return correct responses.